### PR TITLE
Fix virtual quote shipping method

### DIFF
--- a/src/Observer/SetDefaultShippingObserver.php
+++ b/src/Observer/SetDefaultShippingObserver.php
@@ -72,12 +72,12 @@ class SetDefaultShippingObserver implements ObserverInterface
 
         /** @var Quote $quote */
         $quote = $observer->getData('quote');
+        $shippingAddress = $quote->getShippingAddress();
 
-        if ($quote->isVirtual()) {
+        if ($shippingAddress->getShippingMethod() && $quote->isVirtual()) {
+            $shippingAddress->setShippingMethod(null);
             return;
         }
-
-        $shippingAddress = $quote->getShippingAddress();
 
         if (!$shippingAddress->getShippingMethod()) {
             if (!$shippingAddress->getCountryId()) {

--- a/src/Observer/SetDefaultShippingObserver.php
+++ b/src/Observer/SetDefaultShippingObserver.php
@@ -74,7 +74,7 @@ class SetDefaultShippingObserver implements ObserverInterface
         $quote = $observer->getData('quote');
         $shippingAddress = $quote->getShippingAddress();
 
-        if ($shippingAddress->getShippingMethod() && $quote->isVirtual()) {
+        if ($quote->isVirtual()) {
             $shippingAddress->setShippingMethod(null);
             return;
         }

--- a/src/Observer/SetDefaultShippingObserver.php
+++ b/src/Observer/SetDefaultShippingObserver.php
@@ -72,9 +72,14 @@ class SetDefaultShippingObserver implements ObserverInterface
 
         /** @var Quote $quote */
         $quote = $observer->getData('quote');
+
+        if ($quote->isVirtual()) {
+            return;
+        }
+
         $shippingAddress = $quote->getShippingAddress();
 
-        if (!$shippingAddress->getShippingMethod() && !$quote->isVirtual()) {
+        if (!$shippingAddress->getShippingMethod()) {
             if (!$shippingAddress->getCountryId()) {
                 $shippingAddress->setCountryId($this->directoryHelper->getDefaultCountry());
             }

--- a/src/Observer/SetDefaultShippingObserver.php
+++ b/src/Observer/SetDefaultShippingObserver.php
@@ -74,7 +74,7 @@ class SetDefaultShippingObserver implements ObserverInterface
         $quote = $observer->getData('quote');
         $shippingAddress = $quote->getShippingAddress();
 
-        if (!$shippingAddress->getShippingMethod()) {
+        if (!$shippingAddress->getShippingMethod() && !$quote->isVirtual()) {
             if (!$shippingAddress->getCountryId()) {
                 $shippingAddress->setCountryId($this->directoryHelper->getDefaultCountry());
             }

--- a/src/Observer/SetDefaultShippingObserver.php
+++ b/src/Observer/SetDefaultShippingObserver.php
@@ -74,6 +74,11 @@ class SetDefaultShippingObserver implements ObserverInterface
         $quote = $observer->getData('quote');
         $shippingAddress = $quote->getShippingAddress();
 
+        if ($quote->isVirtual()) {
+            $shippingAddress->setShippingMethod(null);
+            return;
+        }
+
         if (!$shippingAddress->getShippingMethod()) {
             if (!$shippingAddress->getCountryId()) {
                 $shippingAddress->setCountryId($this->directoryHelper->getDefaultCountry());


### PR DESCRIPTION
When having a virtual quote a shipping method should not be set on a shipping address as this will break the checkout since 2.2.9.