### PR TITLE
Make sure no shipping method is set when having a virtual quote

### DIFF
--- a/src/Observer/SetDefaultShippingObserver.php
+++ b/src/Observer/SetDefaultShippingObserver.php
@@ -74,6 +74,11 @@ class SetDefaultShippingObserver implements ObserverInterface
         $quote = $observer->getData('quote');
         $shippingAddress = $quote->getShippingAddress();
 
+        if ($quote->isVirtual()) {
+            $shippingAddress->setShippingMethod(null);
+            return;
+        }
+
         if (!$shippingAddress->getShippingMethod()) {
             if (!$shippingAddress->getCountryId()) {
                 $shippingAddress->setCountryId($this->directoryHelper->getDefaultCountry());


### PR DESCRIPTION
When having a virtual quote a shipping method should not be set on a shipping address as this will break the checkout since 2.2.9.