### PR TITLE
fix: jQuery 3.6 support with Magento v2.4.4

### DIFF
--- a/src/view/frontend/web/template/shipping-address/shipping-method-item.html
+++ b/src/view/frontend/web/template/shipping-address/shipping-method-item.html
@@ -10,17 +10,17 @@
                ko-checked="element.isSelected"
                ko-value="method.carrier_code + '_' + method.method_code"
                attr="'aria-labelledby': 'label_method_' + method.method_code + '_' + method.carrier_code + ' ' + 'label_carrier_' + method.method_code + '_' + method.carrier_code,
-                    'checked': element.rates().length == 1 || element.isSelected" />
+                    'checked': element.rates().length == 1 || element.isSelected">
     </td>
     <td class="col col-price">
-        <each args="element.getRegion('price')" render="" />
+        <each args="element.getRegion('price')" render=""></each>
     </td>
     <td class="col col-method"
         attr="'id': 'label_method_' + method.method_code + '_' + method.carrier_code"
-        text="method.method_title" />
+        text="method.method_title"></td>
     <td class="col col-carrier"
         attr="'id': 'label_carrier_' + method.method_code + '_' + method.carrier_code"
-        text="method.carrier_title" />
+        text="method.carrier_title"></td>
 </tr>
 <tr class="row row-error"
     if="method.error_message">
@@ -30,7 +30,7 @@
         </div>
         <span class="no-display">
             <input type="radio"
-                   attr="'value' : method.method_code, 'id': 's_method_' + method.method_code" />
+                   attr="'value' : method.method_code, 'id': 's_method_' + method.method_code">
         </span>
     </td>
 </tr>

--- a/src/view/frontend/web/template/shipping.html
+++ b/src/view/frontend/web/template/shipping.html
@@ -1,12 +1,12 @@
 <li id="shipping" class="checkout-shipping-address" data-bind="fadeVisible: visible()">
-    <div class="step-title" translate="'Shipping Address'" data-role="title" />
+    <div class="step-title" translate="'Shipping Address'" data-role="title"></div>
     <div id="checkout-step-shipping"
          class="step-content"
          data-role="content">
 
-        <each if="!quoteIsVirtual" args="getRegion('customer-email')" render="" />
-        <each args="getRegion('address-list')" render="" />
-        <each args="getRegion('address-list-additional-addresses')" render="" />
+        <each if="!quoteIsVirtual" args="getRegion('customer-email')" render=""></each>
+        <each args="getRegion('address-list')" render=""></each>
+        <each args="getRegion('address-list-additional-addresses')" render=""></each>
 
         <!-- Address form pop up -->
         <if args="!isFormInline">
@@ -14,19 +14,19 @@
                     class="action action-show-popup"
                     click="showFormPopUp"
                     visible="!isNewAddressAdded()">
-                <span translate="'New Address'" />
+                <span translate="'New Address'"></span>
             </button>
             <div id="opc-new-shipping-address"
                  visible="isFormPopUpVisible()"
-                 render="shippingFormTemplate" />
+                 render="shippingFormTemplate"></div>
         </if>
 
-        <each args="getRegion('before-form')" render="" />
+        <each args="getRegion('before-form')" render=""></each>
 
         <!-- Inline address form -->
-        <render if="isFormInline" args="shippingFormTemplate" />
+        <render if="isFormInline" args="shippingFormTemplate"></render>
     </div>
-    <br class="clearfix" />
+    <br class="clearfix">
 </li>
 
 <li id="opc-shipping_method"
@@ -38,10 +38,10 @@
         <!-- ko ifnot: shouldHideShipping() -->
         <div class="step-title"
              translate="'Shipping Methods'"
-             data-role="title" />
+             data-role="title"></div>
         <!-- /ko -->
 
-        <each args="getRegion('before-shipping-method-form')" render="" />
+        <each args="getRegion('before-shipping-method-form')" render=""></each>
 
         <div id="checkout-step-shipping_method"
              class="step-content"
@@ -55,28 +55,28 @@
                   novalidate="novalidate">
 
                 <!-- ko ifnot: shouldHideShipping() -->
-                <render args="shippingMethodListTemplate"/>
+                <render args="shippingMethodListTemplate"></render>
                 <!-- /ko -->
 
                 <div id="onepage-checkout-shipping-method-additional-load">
-                    <each args="getRegion('shippingAdditional')" render="" />
+                    <each args="getRegion('shippingAdditional')" render=""></each>
                 </div>
                 <div role="alert"
                      if="errorValidationMessage().length"
                      class="message notice">
-                    <span text="errorValidationMessage()" />
+                    <span text="errorValidationMessage()"></span>
                 </div>
                 <div class="actions-toolbar" id="shipping-method-buttons-container">
                     <div class="primary">
                         <button data-role="opc-continue" type="submit" class="button action continue primary">
-                            <span translate="'Next'" />
+                            <span translate="'Next'"></span>
                         </button>
                     </div>
                 </div>
             </form>
             <div class="no-quotes-block"
                  ifnot="rates().length > 0"
-                 translate="'Sorry, no quotes are available for this order at this time'" />
+                 translate="'Sorry, no quotes are available for this order at this time'"></div>
         </div>
     </div>
 </li>


### PR DESCRIPTION
With the installation of Magento 2.4.4, and the update of the dependency of jQuery to the 3.6 version, knockout templates must have all HTML tag closed.
Or else, the template is not loaded anymore by jQuery and throw some JS notices :

`JQMIGRATE: HTML tags must be properly nested and closed: *`

Ref : 
1. [The JQuery library has been upgraded to version 3.6. The jquery-ui library has been upgraded to version 1.13.0. Several other JavaScript libraries have been updated to the latest versions.](https://devdocs.magento.com/guides/v2.4/release-notes/open-source-2-4-4.html#platform-enhancements)
2. [MC-41904 Fix HTML tags not properly nested/closed (https://github.com/magento/magento2/pull/18)](https://github.com/magento/magento2/commit/3197b50fd46491ab07cccfeabb289cde0633d79b)